### PR TITLE
fix: exclude `node_modules` when traversing package files

### DIFF
--- a/src/utils/get-all-files.ts
+++ b/src/utils/get-all-files.ts
@@ -38,7 +38,7 @@ export const getAllFilesSync = (
 	dontShortenPath?: boolean,
 ): string[] => {
 	const directoryFiles = fs.readdirSync(directoryPath);
-	const fileTree = directoryFiles.map((fileName) => {
+	const fileTree = directoryFiles.filter(fileName => fileName !== 'node_modules').map((fileName) => {
 		const filePath = path.join(directoryPath, fileName);
 		const stat = fs.statSync(filePath);
 


### PR DESCRIPTION
In case of npm and hoisted node_modules layout, there is high chance no node_modules folder within the package of interest will be present.
And in case if it's present, most likely it will have few dependencies in node_modules folder.

In case of pnpm, *all* the dependencies for the package of interest will be present in node_modules folder within the package.
If package has decent number of dependencies, this can result a really huge nested file structure (even though they will be symlinks).

On my laptop with M1 Pro noticed some packages take 1 second resolve and another package takes 15 seconds and there is a package for which Node.js simply fails with out of memory error.

---

Another option might be to use [`fs.readdirSync`](https://nodejs.org/api/fs.html#fsreaddirsyncpath-options) with `recursive` option, so that we block Node.js process with filesystem operation once instead of doing it as many times as many recoursive directories found in the package and node_modules