### PR TITLE
test: add mitata benchmark for entry-point analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"lint": "lintroll --cache .",
 		"type-check": "tsc",
 		"test": "tsx tests",
+		"benchmark": "tsx --conditions=development scripts/benchmark.ts",
 		"dev": "tsx watch --conditions=development tests",
 		"prepack": "pnpm build && clean-pkg-json"
 	},
@@ -62,6 +63,7 @@
 		"fs-fixture": "^2.9.0",
 		"lintroll": "^1.23.4",
 		"manten": "^1.5.0",
+		"mitata": "^1.0.34",
 		"pkgroll": "^2.19.0",
 		"tsx": "^4.21.0",
 		"type-fest": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       manten:
         specifier: ^1.5.0
         version: 1.5.0
+      mitata:
+        specifier: ^1.0.34
+        version: 1.0.34
       pkgroll:
         specifier: ^2.19.0
         version: 2.19.0(typescript@5.9.3)
@@ -657,56 +660,67 @@ packages:
     resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.4':
     resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.4':
     resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.4':
     resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.4':
     resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.4':
     resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.4':
     resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.4':
     resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.4':
     resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.4':
     resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.4':
     resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.4':
     resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
@@ -896,41 +910,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2073,6 +2095,9 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mitata@1.0.34:
+    resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4922,6 +4947,8 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  mitata@1.0.34: {}
 
   ms@2.1.3: {}
 

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,0 +1,168 @@
+import type nodeFs from 'node:fs';
+import {
+	run, bench, summary, boxplot, do_not_optimize as doNotOptimize,
+} from 'mitata';
+import type { PackageJson } from 'type-fest';
+import { getPackageEntryPointsSync } from '#pkg-entry-points';
+
+/**
+ * Benchmark the analysis path with an in-memory file system.
+ *
+ * `getPackageEntryPoints` is dominated by one `readdir` syscall whose cost is
+ * the OS's, not ours. To measure what this library actually computes — and to
+ * get low-variance numbers comparable across branches — we inject a
+ * deterministic `fs` (a feature the public API already supports) instead of
+ * touching disk. This exercises the full `readFile -> readdir -> collectFiles
+ * -> analyzeExports` path with zero I/O noise.
+ *
+ * A real-filesystem benchmark belongs with the change that optimizes the walk
+ * itself; this one tracks the in-memory analysis.
+ */
+
+type Manifest = {
+	name?: string;
+	main?: string;
+	exports?: PackageJson.Exports;
+};
+
+const root = '/pkg';
+
+const createFs = (
+	manifest: Manifest,
+	files: string[],
+) => {
+	const manifestString = JSON.stringify(manifest);
+	const dirents = files.map((relativePath) => {
+		const slash = relativePath.lastIndexOf('/');
+		return {
+			name: slash === -1 ? relativePath : relativePath.slice(slash + 1),
+			parentPath: slash === -1 ? root : `${root}/${relativePath.slice(0, slash)}`,
+			isFile: () => true,
+		};
+	});
+
+	return {
+		readFileSync: () => manifestString,
+		readdirSync: () => dirents,
+	} as unknown as typeof nodeFs;
+};
+
+const exportsFs = (
+	exports: PackageJson.Exports,
+	files: string[],
+) => createFs(
+	{
+		name: 'pkg',
+		exports,
+	},
+	files,
+);
+
+const distFiles = (count: number) => {
+	const extensions = ['js', 'mjs', 'd.ts'];
+	const files = ['index.js', 'index.mjs', 'index.d.ts'];
+	for (let i = 0; i < count; i += 1) {
+		files.push(`dist/feature-${i % 20}/mod-${i}.${extensions[i % 3]}`);
+	}
+	return files;
+};
+
+const rootEntry = {
+	types: './index.d.ts',
+	import: './index.mjs',
+	require: './index.js',
+};
+
+const starEntry = {
+	types: './dist/*.d.ts',
+	import: './dist/*.mjs',
+	require: './dist/*.js',
+};
+
+const wildcardExports: PackageJson.Exports = {
+	'.': rootEntry,
+	'./*': starEntry,
+};
+
+const wildcardWithBlocks = () => {
+	const exportsMap: Record<string, unknown> = {
+		'.': rootEntry,
+		'./*': starEntry,
+	};
+	for (let i = 0; i < 16; i += 1) {
+		exportsMap[`./internal-${i}/*`] = null;
+	}
+	return exportsMap as PackageJson.Exports;
+};
+
+const explicitConditions = () => {
+	const exportsMap: Record<string, unknown> = {
+		'.': rootEntry,
+	};
+	for (let i = 0; i < 16; i += 1) {
+		exportsMap[`./feature-${i}`] = {
+			node: {
+				import: './index.mjs',
+				require: './index.js',
+			},
+			browser: ['./index.mjs', './index.js'],
+			default: './index.js',
+		};
+	}
+	return exportsMap as PackageJson.Exports;
+};
+
+const legacyFiles = (count: number) => {
+	const files = distFiles(count);
+	files.push('LICENSE', 'README.md', 'index.js.map');
+	return files;
+};
+
+const legacyManifest: Manifest = {
+	name: 'pkg',
+	main: './index.js',
+};
+
+// File systems are built once, up front, so only the analysis itself is timed.
+const scaling = [256, 1024, 4096].map(count => ({
+	count,
+	fs: exportsFs(wildcardExports, distFiles(count)),
+}));
+
+const wildcardFs = exportsFs(wildcardExports, distFiles(1024));
+const blocksFs = exportsFs(wildcardWithBlocks(), distFiles(1024));
+const conditionsFs = exportsFs(explicitConditions(), distFiles(64));
+const legacyFs = createFs(legacyManifest, legacyFiles(1024));
+
+boxplot(() => {
+	for (const { count, fs } of scaling) {
+		bench(
+			`wildcard exports · ${count} files`,
+			() => doNotOptimize(getPackageEntryPointsSync(root, fs)),
+		);
+	}
+});
+
+summary(() => {
+	bench(
+		'wildcard exports',
+		() => doNotOptimize(getPackageEntryPointsSync(root, wildcardFs)),
+	);
+	bench(
+		'wildcard exports + null blocks',
+		() => doNotOptimize(getPackageEntryPointsSync(root, blocksFs)),
+	);
+	bench(
+		'explicit subpaths + conditions',
+		() => doNotOptimize(getPackageEntryPointsSync(root, conditionsFs)),
+	);
+	bench(
+		'legacy (no exports field)',
+		() => doNotOptimize(getPackageEntryPointsSync(root, legacyFs)),
+	);
+});
+
+run().catch((error: unknown) => {
+	process.exitCode = 1;
+	throw error;
+});

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -129,40 +129,42 @@ const scaling = [256, 1024, 4096].map(count => ({
 	fs: exportsFs(wildcardExports, distFiles(count)),
 }));
 
-const wildcardFs = exportsFs(wildcardExports, distFiles(1024));
-const blocksFs = exportsFs(wildcardWithBlocks(), distFiles(1024));
-const conditionsFs = exportsFs(explicitConditions(), distFiles(64));
-const legacyFs = createFs(legacyManifest, legacyFiles(1024));
+const scenarios = [
+	{
+		name: 'wildcard exports',
+		fs: exportsFs(wildcardExports, distFiles(1024)),
+	},
+	{
+		name: 'wildcard exports + null blocks',
+		fs: exportsFs(wildcardWithBlocks(), distFiles(1024)),
+	},
+	{
+		name: 'explicit subpaths + conditions',
+		fs: exportsFs(explicitConditions(), distFiles(64)),
+	},
+	{
+		name: 'legacy (no exports field)',
+		fs: createFs(legacyManifest, legacyFiles(1024)),
+	},
+];
+
+const measure = (fs: typeof nodeFs) => doNotOptimize(getPackageEntryPointsSync(root, fs));
 
 boxplot(() => {
 	for (const { count, fs } of scaling) {
-		bench(
-			`wildcard exports · ${count} files`,
-			() => doNotOptimize(getPackageEntryPointsSync(root, fs)),
-		);
+		bench(`wildcard exports · ${count} files`, () => measure(fs));
 	}
 });
 
 summary(() => {
-	bench(
-		'wildcard exports',
-		() => doNotOptimize(getPackageEntryPointsSync(root, wildcardFs)),
-	);
-	bench(
-		'wildcard exports + null blocks',
-		() => doNotOptimize(getPackageEntryPointsSync(root, blocksFs)),
-	);
-	bench(
-		'explicit subpaths + conditions',
-		() => doNotOptimize(getPackageEntryPointsSync(root, conditionsFs)),
-	);
-	bench(
-		'legacy (no exports field)',
-		() => doNotOptimize(getPackageEntryPointsSync(root, legacyFs)),
-	);
+	for (const { name, fs } of scenarios) {
+		bench(name, () => measure(fs));
+	}
 });
 
-run().catch((error: unknown) => {
+// `throw: true` so a broken benchmark (e.g. the fake fs drifting from the real
+// API) fails the command instead of silently reporting success.
+run({ throw: true }).catch((error: unknown) => {
 	process.exitCode = 1;
 	throw error;
 });


### PR DESCRIPTION
Adds a `benchmark` script so analysis-path perf changes are measurable and comparable across branches. Intended to merge **before** #39 so we can record a clean before/after.

## What

`pnpm benchmark` runs a [mitata](https://github.com/evanwashere/mitata) suite over `getPackageEntryPointsSync`:

- **scaling** (boxplot): wildcard `"./*"` exports over 256 / 1024 / 4096 files
- **scenarios** (summary): wildcard, wildcard + null blocks, explicit subpaths + conditions, legacy (no `exports`)

## Why an in-memory `fs`

A real call is dominated by one `readdir` syscall whose cost is the OS's, not ours. To measure what this library actually computes — with low variance and clean cross-branch comparisons — the benchmark injects a deterministic `fs` through the public API's existing `fs` parameter. This exercises the full `readFile → readdir → collectFiles → analyzeExports` path with zero I/O noise.

(A real-filesystem benchmark belongs with the change that optimizes the walk itself; this one tracks the in-memory analysis.)

## Recording a before/after

1. Merge this PR into `develop`.
2. `pnpm benchmark` on `develop` → baseline.
3. Rebase the perf branch (#39) onto `develop` and `pnpm benchmark` → compare.

## Notes

- Lives in `scripts/` so lintroll treats it as dev tooling (the `mitata` devDependency import is allowed there).
- No runtime / `src` changes; `test:`-typed so it doesn't trigger a release.
