### PR TITLE
perf: scope file discovery to what exports references

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -32,18 +32,58 @@ const createFs = (
 	files: string[],
 ) => {
 	const manifestString = JSON.stringify(manifest);
-	const dirents = files.map((relativePath) => {
-		const slash = relativePath.lastIndexOf('/');
-		return {
-			name: slash === -1 ? relativePath : relativePath.slice(slash + 1),
-			parentPath: slash === -1 ? root : `${root}/${relativePath.slice(0, slash)}`,
+
+	// Build an in-memory directory tree so per-directory `readdir` works
+	// (the analysis now walks one directory at a time).
+	type DirectoryNode = {
+		files: string[];
+		dirs: Set<string>;
+	};
+	const children = new Map<string, DirectoryNode>();
+	const directory = (absolute: string) => {
+		let node = children.get(absolute);
+		if (!node) {
+			node = {
+				files: [],
+				dirs: new Set(),
+			};
+			children.set(absolute, node);
+		}
+		return node;
+	};
+	directory(root);
+	for (const file of files) {
+		const segments = file.split('/');
+		let absolute = root;
+		for (let i = 0; i < segments.length - 1; i += 1) {
+			directory(absolute).dirs.add(segments[i]);
+			absolute += `/${segments[i]}`;
+			directory(absolute);
+		}
+		directory(absolute).files.push(segments.at(-1)!);
+	}
+
+	const readdirSync = (absolute: string) => {
+		const node = children.get(absolute);
+		if (!node) {
+			return [];
+		}
+		const directories = Array.from(node.dirs, name => ({
+			name,
+			isFile: () => false,
+			isDirectory: () => true,
+		}));
+		const fileEntries = node.files.map(name => ({
+			name,
 			isFile: () => true,
-		};
-	});
+			isDirectory: () => false,
+		}));
+		return [...directories, ...fileEntries];
+	};
 
 	return {
 		readFileSync: () => manifestString,
-		readdirSync: () => dirents,
+		readdirSync,
 	} as unknown as typeof nodeFs;
 };
 

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -81,9 +81,24 @@ const createFs = (
 		return [...directories, ...fileEntries];
 	};
 
+	const lstatSync = (absolute: string) => {
+		const slash = absolute.lastIndexOf('/');
+		const parent = children.get(absolute.slice(0, slash));
+		const isFile = parent?.files.includes(absolute.slice(slash + 1)) ?? false;
+		const isDirectory = children.has(absolute);
+		if (!isFile && !isDirectory) {
+			throw new Error(`ENOENT: ${absolute}`);
+		}
+		return {
+			isFile: () => isFile,
+			isDirectory: () => isDirectory,
+		};
+	};
+
 	return {
 		readFileSync: () => manifestString,
 		readdirSync,
+		lstatSync,
 	} as unknown as typeof nodeFs;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import _fs from 'fs';
 import path from 'path';
 import type { PackageJson } from 'type-fest';
-import { getAllFiles, getAllFilesSync } from './utils/get-all-files.js';
+import {
+	getAllFiles, getAllFilesSync, discoverReferencedFiles, discoverReferencedFilesSync,
+} from './utils/get-all-files.js';
 import { createPathMatcher, pathMatches, type PathMatcher } from './utils/path-matcher.js';
 import { STAR } from './utils/constants.js';
 import { resolveLegacyEntries } from './resolve-legacy-entries.js';
@@ -275,12 +277,13 @@ export const getPackageEntryPoints = async (
 ): Promise<PackageEntryPoints> => {
 	const packageJsonString = await fs.readFile(path.join(packagePath, 'package.json'), 'utf8');
 	const packageJson = JSON.parse(packageJsonString) as PackageJson;
-	const packageFiles = await getAllFiles(fs, packagePath);
 
 	if (packageJson.exports !== undefined) {
+		const packageFiles = await discoverReferencedFiles(fs, packagePath, packageJson.exports);
 		return analyzeExportsWithFiles(packageJson.exports, packageFiles);
 	}
 
+	const packageFiles = await getAllFiles(fs, packagePath);
 	return resolveLegacyEntries(packageJson, packageFiles);
 };
 
@@ -290,11 +293,12 @@ export const getPackageEntryPointsSync = (
 ): PackageEntryPoints => {
 	const packageJsonString = fs.readFileSync(path.join(packagePath, 'package.json'), 'utf8');
 	const packageJson = JSON.parse(packageJsonString) as PackageJson;
-	const packageFiles = getAllFilesSync(fs, packagePath);
 
 	if (packageJson.exports !== undefined) {
+		const packageFiles = discoverReferencedFilesSync(fs, packagePath, packageJson.exports);
 		return analyzeExportsWithFiles(packageJson.exports, packageFiles);
 	}
 
+	const packageFiles = getAllFilesSync(fs, packagePath);
 	return resolveLegacyEntries(packageJson, packageFiles);
 };

--- a/src/utils/get-all-files.ts
+++ b/src/utils/get-all-files.ts
@@ -97,18 +97,44 @@ export const getAllFilesSync = (
 };
 
 /**
- * Collect every `./`-relative string target from an `exports` subtree.
+ * Whether a relative target is a safe package-relative path. Mirrors Node's
+ * `PACKAGE_TARGET_RESOLVE`, which rejects targets with empty, `.`, `..`, or
+ * `node_modules` segments — they escape the package or are invalid, and were
+ * never matched by the full scan either. Without this, `path.join` would
+ * normalize e.g. `./dist/../index.js` and stat paths outside the package.
+ */
+const isValidTarget = (
+	target: string,
+) => {
+	const segments = target.split('/');
+	// segments[0] is the leading '.'; validate the rest.
+	for (let i = 1; i < segments.length; i += 1) {
+		const segment = segments[i].toLowerCase();
+		if (
+			segment === ''
+			|| segment === '.'
+			|| segment === '..'
+			|| segment === 'node_modules'
+		) {
+			return false;
+		}
+	}
+	return true;
+};
+
+/**
+ * Collect every safe `./`-relative string target from an `exports` subtree.
  *
  * Only relative (`./`) targets can resolve to real files; bare/URL/protocol
- * targets and `null` are skipped. Object keys (subpaths/conditions) are not
- * targets — only values are.
+ * targets, `null`, and path-escaping targets are skipped. Object keys
+ * (subpaths/conditions) are not targets — only values are.
  */
 const collectExportTargets = (
 	exportsValue: PackageJson.Exports,
 	targets: Set<string>,
 ): void => {
 	if (typeof exportsValue === 'string') {
-		if (exportsValue.startsWith('./')) {
+		if (exportsValue.startsWith('./') && isValidTarget(exportsValue)) {
 			targets.add(exportsValue);
 		}
 	} else if (Array.isArray(exportsValue)) {

--- a/src/utils/get-all-files.ts
+++ b/src/utils/get-all-files.ts
@@ -1,5 +1,7 @@
 import type _fs from 'fs';
 import path from 'path';
+import type { PackageJson } from 'type-fest';
+import { STAR } from './constants.js';
 
 const stripTrailingSeparator = (
 	directoryPath: string,
@@ -10,46 +12,78 @@ const stripTrailingSeparator = (
 );
 
 /**
- * Recursively walk a directory, collecting files as `./`-relative paths.
+ * Recursively walk a directory, pushing files as `./`-relative paths.
  *
  * Manual walk (rather than `readdir({ recursive: true })`) so we can:
  * - prune `node_modules` only at the package root, without descending into it
  *   (files under a *nested* `node_modules` are still listed, as before)
  * - skip symlinks consistently across sync and async (recursive `readdirSync`
  *   followed symlinked directories; async `readdir` did not)
- * - build paths by concatenation instead of normalizing every entry
  *
  * `relativePrefix` is the path from the package root to `absoluteDirectory`,
  * with a trailing separator (empty at the root). The root `node_modules` is
- * the one whose `relativePrefix` is empty.
+ * the one reached while `relativePrefix` is empty.
+ */
+const walkDirectory = async (
+	fs: Pick<typeof _fs.promises, 'readdir'>,
+	absoluteDirectory: string,
+	relativePrefix: string,
+	result: string[],
+): Promise<void> => {
+	const entries = await fs.readdir(absoluteDirectory, { withFileTypes: true });
+	for (const entry of entries) {
+		if (entry.isDirectory()) {
+			if (relativePrefix === '' && entry.name === 'node_modules') {
+				continue;
+			}
+			await walkDirectory(
+				fs,
+				`${absoluteDirectory}${path.sep}${entry.name}`,
+				`${relativePrefix}${entry.name}${path.sep}`,
+				result,
+			);
+		} else if (entry.isFile()) {
+			result.push(`./${relativePrefix}${entry.name}`);
+		}
+	}
+};
+
+const walkDirectorySync = (
+	fs: Pick<typeof _fs, 'readdirSync'>,
+	absoluteDirectory: string,
+	relativePrefix: string,
+	result: string[],
+): void => {
+	const entries = fs.readdirSync(absoluteDirectory, { withFileTypes: true });
+	for (const entry of entries) {
+		if (entry.isDirectory()) {
+			if (relativePrefix === '' && entry.name === 'node_modules') {
+				continue;
+			}
+			walkDirectorySync(
+				fs,
+				`${absoluteDirectory}${path.sep}${entry.name}`,
+				`${relativePrefix}${entry.name}${path.sep}`,
+				result,
+			);
+		} else if (entry.isFile()) {
+			result.push(`./${relativePrefix}${entry.name}`);
+		}
+	}
+};
+
+/**
+ * List every file in a package as `./`-relative paths.
+ *
+ * Used for legacy packages (no `exports`), where every file is a potential
+ * entry point so the whole tree must be scanned.
  */
 export const getAllFiles = async (
 	fs: Pick<typeof _fs.promises, 'readdir'>,
 	directoryPath: string,
 ): Promise<string[]> => {
 	const result: string[] = [];
-
-	const walk = async (
-		absoluteDirectory: string,
-		relativePrefix: string,
-	): Promise<void> => {
-		const entries = await fs.readdir(absoluteDirectory, { withFileTypes: true });
-		for (const entry of entries) {
-			if (entry.isDirectory()) {
-				if (relativePrefix === '' && entry.name === 'node_modules') {
-					continue;
-				}
-				await walk(
-					`${absoluteDirectory}${path.sep}${entry.name}`,
-					`${relativePrefix}${entry.name}${path.sep}`,
-				);
-			} else if (entry.isFile()) {
-				result.push(`./${relativePrefix}${entry.name}`);
-			}
-		}
-	};
-
-	await walk(stripTrailingSeparator(directoryPath), '');
+	await walkDirectory(fs, stripTrailingSeparator(directoryPath), '', result);
 	return result;
 };
 
@@ -58,27 +92,167 @@ export const getAllFilesSync = (
 	directoryPath: string,
 ): string[] => {
 	const result: string[] = [];
+	walkDirectorySync(fs, stripTrailingSeparator(directoryPath), '', result);
+	return result;
+};
 
-	const walk = (
-		absoluteDirectory: string,
-		relativePrefix: string,
-	): void => {
-		const entries = fs.readdirSync(absoluteDirectory, { withFileTypes: true });
-		for (const entry of entries) {
-			if (entry.isDirectory()) {
-				if (relativePrefix === '' && entry.name === 'node_modules') {
-					continue;
-				}
-				walk(
-					`${absoluteDirectory}${path.sep}${entry.name}`,
-					`${relativePrefix}${entry.name}${path.sep}`,
-				);
-			} else if (entry.isFile()) {
-				result.push(`./${relativePrefix}${entry.name}`);
+/**
+ * Collect every `./`-relative string target from an `exports` subtree.
+ *
+ * Only relative (`./`) targets can resolve to real files; bare/URL/protocol
+ * targets and `null` are skipped. Object keys (subpaths/conditions) are not
+ * targets — only values are.
+ */
+const collectExportTargets = (
+	exportsValue: PackageJson.Exports,
+	targets: Set<string>,
+): void => {
+	if (typeof exportsValue === 'string') {
+		if (exportsValue.startsWith('./')) {
+			targets.add(exportsValue);
+		}
+	} else if (Array.isArray(exportsValue)) {
+		for (const value of exportsValue) {
+			collectExportTargets(value, targets);
+		}
+	} else if (exportsValue && typeof exportsValue === 'object') {
+		const object = exportsValue as Record<string, PackageJson.Exports>;
+		for (const key in object) {
+			if (Object.hasOwn(object, key)) {
+				collectExportTargets(object[key], targets);
 			}
 		}
-	};
+	}
+};
 
-	walk(stripTrailingSeparator(directoryPath), '');
-	return result;
+/**
+ * The package-relative directory a wildcard target's matches live under:
+ * everything before the first `*`, up to the last separator. Empty = root.
+ * (Uses only the first `*`; values may contain several, all bound to the
+ * same capture, and everything before the first is a literal prefix.)
+ */
+const wildcardDirectory = (
+	target: string,
+) => {
+	const literalPrefix = target.slice(0, target.indexOf(STAR));
+	return literalPrefix.slice(2, literalPrefix.lastIndexOf('/'));
+};
+
+const toAbsolute = (
+	packagePath: string,
+	relativeDirectory: string,
+) => (
+	relativeDirectory
+		? path.join(packagePath, relativeDirectory)
+		: packagePath
+);
+
+const toRelativePrefix = (
+	relativeDirectory: string,
+) => (
+	relativeDirectory
+		? `${relativeDirectory.split('/').join(path.sep)}${path.sep}`
+		: ''
+);
+
+/**
+ * Discover only the files an `exports` map references, instead of scanning the
+ * whole package: walk the directory each wildcard target points into, and
+ * `lstat` each explicit target. The result is a superset sufficient for
+ * `analyzeExportsWithFiles` to produce the same output as a full scan.
+ *
+ * `lstat` (not `stat`) so symlinked targets are excluded, matching the full
+ * scan, which skips symlinks.
+ */
+export const discoverReferencedFiles = async (
+	fs: Pick<typeof _fs.promises, 'readdir' | 'lstat'>,
+	packagePath: string,
+	exports: PackageJson.Exports,
+): Promise<string[]> => {
+	const targets = new Set<string>();
+	collectExportTargets(exports, targets);
+
+	const wildcardDirectories = new Set<string>();
+	const explicitTargets: string[] = [];
+	for (const target of Array.from(targets)) {
+		if (target.includes(STAR)) {
+			wildcardDirectories.add(wildcardDirectory(target));
+		} else {
+			explicitTargets.push(target);
+		}
+	}
+
+	const files = new Set<string>();
+
+	await Promise.all([
+		...Array.from(wildcardDirectories, async (relativeDirectory) => {
+			const collected: string[] = [];
+			try {
+				await walkDirectory(
+					fs,
+					toAbsolute(packagePath, relativeDirectory),
+					toRelativePrefix(relativeDirectory),
+					collected,
+				);
+			} catch {
+				// Referenced directory may not exist; nothing to contribute.
+			}
+			for (const file of collected) {
+				files.add(file);
+			}
+		}),
+		...explicitTargets.map(async (target) => {
+			try {
+				const stats = await fs.lstat(path.join(packagePath, target));
+				if (stats.isFile()) {
+					files.add(target);
+				}
+			} catch {
+				// Missing target; not an entry point.
+			}
+		}),
+	]);
+
+	return Array.from(files);
+};
+
+export const discoverReferencedFilesSync = (
+	fs: Pick<typeof _fs, 'readdirSync' | 'lstatSync'>,
+	packagePath: string,
+	exports: PackageJson.Exports,
+): string[] => {
+	const targets = new Set<string>();
+	collectExportTargets(exports, targets);
+
+	const files = new Set<string>();
+	for (const target of Array.from(targets)) {
+		if (target.includes(STAR)) {
+			const relativeDirectory = wildcardDirectory(target);
+			const collected: string[] = [];
+			try {
+				walkDirectorySync(
+					fs,
+					toAbsolute(packagePath, relativeDirectory),
+					toRelativePrefix(relativeDirectory),
+					collected,
+				);
+			} catch {
+				// Referenced directory may not exist.
+			}
+			for (const file of collected) {
+				files.add(file);
+			}
+		} else {
+			try {
+				const stats = fs.lstatSync(path.join(packagePath, target));
+				if (stats.isFile()) {
+					files.add(target);
+				}
+			} catch {
+				// Missing target.
+			}
+		}
+	}
+
+	return Array.from(files);
 };

--- a/src/utils/get-all-files.ts
+++ b/src/utils/get-all-files.ts
@@ -1,95 +1,84 @@
 import type _fs from 'fs';
 import path from 'path';
 
-const nodeModulesPath = `node_modules${path.sep}`;
-
-type Dirent = {
-	name: string;
-	parentPath: string;
-	isFile: () => boolean;
-};
-
-/**
- * Convert recursive readdir entries to package-relative paths.
- *
- * In a recursive listing, every `entry.parentPath` is `directoryPath` itself or
- * a descendant of it, so the package-relative path is a plain string slice and
- * the entry path is a concatenation. This avoids `path.relative`/`path.join`
- * normalizing every entry, which dominates the cost of scanning large packages.
- */
-const collectFiles = (
-	entries: Dirent[],
+const stripTrailingSeparator = (
 	directoryPath: string,
-): string[] => {
-	// Offset of the first character after `directoryPath` and its separator.
-	const baseLength = (
-		directoryPath.endsWith(path.sep)
-			? directoryPath.length - 1
-			: directoryPath.length
-	) + 1;
-
-	const result: string[] = [];
-	for (const entry of entries) {
-		if (!entry.isFile()) {
-			continue;
-		}
-
-		const { parentPath } = entry;
-		const relativeParentPath = (
-			parentPath.length > baseLength
-				? parentPath.slice(baseLength)
-				: ''
-		);
-		if (relativeParentPath.startsWith(nodeModulesPath)) {
-			continue;
-		}
-
-		result.push(
-			relativeParentPath
-				? `./${relativeParentPath}${path.sep}${entry.name}`
-				: `./${entry.name}`,
-		);
-	}
-
-	return result;
-};
+) => (
+	directoryPath.endsWith(path.sep)
+		? directoryPath.slice(0, -1)
+		: directoryPath
+);
 
 /**
- * Recursively list all files in a directory.
+ * Recursively walk a directory, collecting files as `./`-relative paths.
  *
- * Required for legacy packages (without exports field) where every JS file
- * is a potential entry point. Cannot be made lazy without breaking the contract.
+ * Manual walk (rather than `readdir({ recursive: true })`) so we can:
+ * - prune `node_modules` only at the package root, without descending into it
+ *   (files under a *nested* `node_modules` are still listed, as before)
+ * - skip symlinks consistently across sync and async (recursive `readdirSync`
+ *   followed symlinked directories; async `readdir` did not)
+ * - build paths by concatenation instead of normalizing every entry
  *
- * Uses recursive readdir (Node 20.1.0+) to get all files in a single syscall.
+ * `relativePrefix` is the path from the package root to `absoluteDirectory`,
+ * with a trailing separator (empty at the root). The root `node_modules` is
+ * the one whose `relativePrefix` is empty.
  */
 export const getAllFiles = async (
 	fs: Pick<typeof _fs.promises, 'readdir'>,
 	directoryPath: string,
 ): Promise<string[]> => {
-	const entries = await fs.readdir(directoryPath, {
-		recursive: true,
-		withFileTypes: true,
-	});
+	const result: string[] = [];
 
-	return collectFiles(entries, directoryPath);
+	const walk = async (
+		absoluteDirectory: string,
+		relativePrefix: string,
+	): Promise<void> => {
+		const entries = await fs.readdir(absoluteDirectory, { withFileTypes: true });
+		for (const entry of entries) {
+			if (entry.isDirectory()) {
+				if (relativePrefix === '' && entry.name === 'node_modules') {
+					continue;
+				}
+				await walk(
+					`${absoluteDirectory}${path.sep}${entry.name}`,
+					`${relativePrefix}${entry.name}${path.sep}`,
+				);
+			} else if (entry.isFile()) {
+				result.push(`./${relativePrefix}${entry.name}`);
+			}
+		}
+	};
+
+	await walk(stripTrailingSeparator(directoryPath), '');
+	return result;
 };
 
-/**
- * Synchronous version of getAllFiles.
- *
- * Required for legacy packages (without exports field) where every JS file
- * is a potential entry point. Cannot be made lazy without breaking the contract.
- *
- * Uses recursive readdir (Node 20.1.0+) to get all files in a single syscall.
- */
 export const getAllFilesSync = (
 	fs: Pick<typeof _fs, 'readdirSync'>,
 	directoryPath: string,
 ): string[] => {
-	const entries = fs.readdirSync(directoryPath, {
-		recursive: true,
-		withFileTypes: true,
-	});
+	const result: string[] = [];
 
-	return collectFiles(entries, directoryPath);
+	const walk = (
+		absoluteDirectory: string,
+		relativePrefix: string,
+	): void => {
+		const entries = fs.readdirSync(absoluteDirectory, { withFileTypes: true });
+		for (const entry of entries) {
+			if (entry.isDirectory()) {
+				if (relativePrefix === '' && entry.name === 'node_modules') {
+					continue;
+				}
+				walk(
+					`${absoluteDirectory}${path.sep}${entry.name}`,
+					`${relativePrefix}${entry.name}${path.sep}`,
+				);
+			} else if (entry.isFile()) {
+				result.push(`./${relativePrefix}${entry.name}`);
+			}
+		}
+	};
+
+	walk(stripTrailingSeparator(directoryPath), '');
+	return result;
 };

--- a/src/utils/get-all-files.ts
+++ b/src/utils/get-all-files.ts
@@ -155,6 +155,65 @@ const toRelativePrefix = (
 		: ''
 );
 
+// A path that simply isn't there. Other errors (e.g. EACCES) should surface.
+const isMissing = (
+	error: unknown,
+) => {
+	const code = (error as NodeJS.ErrnoException | null)?.code;
+	return code === 'ENOENT' || code === 'ENOTDIR';
+};
+
+// `lstat` a path, returning undefined if it's absent but surfacing real errors.
+const tryLstat = async (
+	fs: Pick<typeof _fs.promises, 'lstat'>,
+	absolutePath: string,
+) => {
+	try {
+		return await fs.lstat(absolutePath);
+	} catch (error) {
+		if (!isMissing(error)) {
+			throw error;
+		}
+		return undefined;
+	}
+};
+
+const tryLstatSync = (
+	fs: Pick<typeof _fs, 'lstatSync'>,
+	absolutePath: string,
+) => {
+	try {
+		return fs.lstatSync(absolutePath);
+	} catch (error) {
+		if (!isMissing(error)) {
+			throw error;
+		}
+		return undefined;
+	}
+};
+
+const partitionTargets = (
+	exports: PackageJson.Exports,
+) => {
+	const targets = new Set<string>();
+	collectExportTargets(exports, targets);
+
+	const wildcardDirectories = new Set<string>();
+	const explicitTargets = new Set<string>();
+	for (const target of Array.from(targets)) {
+		if (target.includes(STAR)) {
+			wildcardDirectories.add(wildcardDirectory(target));
+		} else {
+			explicitTargets.add(target);
+		}
+	}
+
+	return {
+		wildcardDirectories,
+		explicitTargets,
+	};
+};
+
 /**
  * Discover only the files an `exports` map references, instead of scanning the
  * whole package: walk the directory each wildcard target points into, and
@@ -169,46 +228,27 @@ export const discoverReferencedFiles = async (
 	packagePath: string,
 	exports: PackageJson.Exports,
 ): Promise<string[]> => {
-	const targets = new Set<string>();
-	collectExportTargets(exports, targets);
-
-	const wildcardDirectories = new Set<string>();
-	const explicitTargets: string[] = [];
-	for (const target of Array.from(targets)) {
-		if (target.includes(STAR)) {
-			wildcardDirectories.add(wildcardDirectory(target));
-		} else {
-			explicitTargets.push(target);
-		}
-	}
-
+	const { wildcardDirectories, explicitTargets } = partitionTargets(exports);
 	const files = new Set<string>();
 
 	await Promise.all([
 		...Array.from(wildcardDirectories, async (relativeDirectory) => {
-			const collected: string[] = [];
-			try {
-				await walkDirectory(
-					fs,
-					toAbsolute(packagePath, relativeDirectory),
-					toRelativePrefix(relativeDirectory),
-					collected,
-				);
-			} catch {
-				// Referenced directory may not exist; nothing to contribute.
+			const absoluteDirectory = toAbsolute(packagePath, relativeDirectory);
+			const stats = await tryLstat(fs, absoluteDirectory);
+			// Skip missing dirs and symlinked roots (the latter to match the full walk).
+			if (!stats?.isDirectory()) {
+				return;
 			}
+			const collected: string[] = [];
+			await walkDirectory(fs, absoluteDirectory, toRelativePrefix(relativeDirectory), collected);
 			for (const file of collected) {
 				files.add(file);
 			}
 		}),
-		...explicitTargets.map(async (target) => {
-			try {
-				const stats = await fs.lstat(path.join(packagePath, target));
-				if (stats.isFile()) {
-					files.add(target);
-				}
-			} catch {
-				// Missing target; not an entry point.
+		...Array.from(explicitTargets, async (target) => {
+			const stats = await tryLstat(fs, path.join(packagePath, target));
+			if (stats?.isFile()) {
+				files.add(target);
 			}
 		}),
 	]);
@@ -221,36 +261,27 @@ export const discoverReferencedFilesSync = (
 	packagePath: string,
 	exports: PackageJson.Exports,
 ): string[] => {
-	const targets = new Set<string>();
-	collectExportTargets(exports, targets);
-
+	const { wildcardDirectories, explicitTargets } = partitionTargets(exports);
 	const files = new Set<string>();
-	for (const target of Array.from(targets)) {
-		if (target.includes(STAR)) {
-			const relativeDirectory = wildcardDirectory(target);
-			const collected: string[] = [];
-			try {
-				walkDirectorySync(
-					fs,
-					toAbsolute(packagePath, relativeDirectory),
-					toRelativePrefix(relativeDirectory),
-					collected,
-				);
-			} catch {
-				// Referenced directory may not exist.
-			}
-			for (const file of collected) {
-				files.add(file);
-			}
-		} else {
-			try {
-				const stats = fs.lstatSync(path.join(packagePath, target));
-				if (stats.isFile()) {
-					files.add(target);
-				}
-			} catch {
-				// Missing target.
-			}
+
+	for (const relativeDirectory of Array.from(wildcardDirectories)) {
+		const absoluteDirectory = toAbsolute(packagePath, relativeDirectory);
+		const stats = tryLstatSync(fs, absoluteDirectory);
+		// Skip missing dirs and symlinked roots (the latter to match the full walk).
+		if (!stats?.isDirectory()) {
+			continue;
+		}
+		const collected: string[] = [];
+		walkDirectorySync(fs, absoluteDirectory, toRelativePrefix(relativeDirectory), collected);
+		for (const file of collected) {
+			files.add(file);
+		}
+	}
+
+	for (const target of Array.from(explicitTargets)) {
+		const stats = tryLstatSync(fs, path.join(packagePath, target));
+		if (stats?.isFile()) {
+			files.add(target);
 		}
 	}
 

--- a/src/utils/get-all-files.ts
+++ b/src/utils/get-all-files.ts
@@ -106,7 +106,9 @@ export const getAllFilesSync = (
 const isValidTarget = (
 	target: string,
 ) => {
-	const segments = target.split('/');
+	// Split on both separators: `path.join` treats `\` as a separator too, so
+	// `./..\secret` must not slip past on Windows.
+	const segments = target.split(/[\\/]/);
 	// segments[0] is the leading '.'; validate the rest.
 	for (let i = 1; i < segments.length; i += 1) {
 		const segment = segments[i].toLowerCase();
@@ -260,10 +262,14 @@ export const discoverReferencedFiles = async (
 	await Promise.all([
 		...Array.from(wildcardDirectories, async (relativeDirectory) => {
 			const absoluteDirectory = toAbsolute(packagePath, relativeDirectory);
-			const stats = await tryLstat(fs, absoluteDirectory);
-			// Skip missing dirs and symlinked roots (the latter to match the full walk).
-			if (!stats?.isDirectory()) {
-				return;
+			// A wildcard into a subdirectory is skipped if it's missing or a symlink
+			// (matching the full walk). The package root is always followed — it may
+			// itself be a symlink (e.g. pnpm `node_modules/<pkg>`), as readdir would.
+			if (relativeDirectory) {
+				const stats = await tryLstat(fs, absoluteDirectory);
+				if (!stats?.isDirectory()) {
+					return;
+				}
 			}
 			const collected: string[] = [];
 			await walkDirectory(fs, absoluteDirectory, toRelativePrefix(relativeDirectory), collected);
@@ -292,10 +298,14 @@ export const discoverReferencedFilesSync = (
 
 	for (const relativeDirectory of Array.from(wildcardDirectories)) {
 		const absoluteDirectory = toAbsolute(packagePath, relativeDirectory);
-		const stats = tryLstatSync(fs, absoluteDirectory);
-		// Skip missing dirs and symlinked roots (the latter to match the full walk).
-		if (!stats?.isDirectory()) {
-			continue;
+		// A wildcard into a subdirectory is skipped if it's missing or a symlink
+		// (matching the full walk). The package root is always followed — it may
+		// itself be a symlink (e.g. pnpm `node_modules/<pkg>`), as readdir would.
+		if (relativeDirectory) {
+			const stats = tryLstatSync(fs, absoluteDirectory);
+			if (!stats?.isDirectory()) {
+				continue;
+			}
 		}
 		const collected: string[] = [];
 		walkDirectorySync(fs, absoluteDirectory, toRelativePrefix(relativeDirectory), collected);

--- a/tests/specs/discovery.ts
+++ b/tests/specs/discovery.ts
@@ -217,6 +217,27 @@ export default testSuite(({ describe }) => {
 					const result = await getEntries(pkg.packagePath);
 					expect(result).toStrictEqual({});
 				});
+
+				test('rejects path-escaping and invalid export targets', async () => {
+					await using pkg = await createPackage({
+						pkg: {
+							'package.json': createPackageJson({
+								exports: {
+									'./traverse': './dist/../index.js',
+									'./escape': './../../secret.js',
+									'./nm': './node_modules/dep.js',
+									'./ok': './index.js',
+								},
+							}),
+							'index.js': 'module.exports = 1',
+						},
+					});
+
+					const result = await getEntries(pkg.packagePath);
+					expect(result).toStrictEqual({
+						'./ok': [[['default'], './index.js']],
+					});
+				});
 			});
 		});
 	}

--- a/tests/specs/discovery.ts
+++ b/tests/specs/discovery.ts
@@ -202,6 +202,21 @@ export default testSuite(({ describe }) => {
 					const result = await getEntries(pkg.packagePath);
 					expect(result).toStrictEqual({});
 				});
+
+				test('does not follow a symlinked wildcard directory', async () => {
+					await using pkg = await createPackage({
+						pkg: {
+							'package.json': createPackageJson({
+								exports: { './*': './linked/*.mjs' },
+							}),
+							'real/a.mjs': 'export default 1',
+							linked: ({ symlink }) => symlink('./real', 'dir'),
+						},
+					});
+
+					const result = await getEntries(pkg.packagePath);
+					expect(result).toStrictEqual({});
+				});
 			});
 		});
 	}
@@ -260,6 +275,49 @@ export default testSuite(({ describe }) => {
 			expect(result).toStrictEqual({
 				'./a': [[['default'], './dist/a.mjs']],
 			});
+		});
+
+		// A real fs error (not a missing path) must surface, not be swallowed.
+		test('async surfaces non-missing fs errors', async () => {
+			await using pkg = await createPackage({
+				pkg: {
+					'package.json': createPackageJson({ exports: './a.mjs' }),
+					'a.mjs': 'export default 1',
+				},
+			});
+
+			const failingFs = new Proxy(fs.promises, {
+				get(target, property) {
+					if (property === 'lstat') {
+						return () => Promise.reject(Object.assign(new Error('denied'), { code: 'EACCES' }));
+					}
+					return target[property as keyof typeof target];
+				},
+			});
+
+			await expect(getPackageEntryPoints(pkg.packagePath, failingFs)).rejects.toThrow('denied');
+		});
+
+		test('sync surfaces non-missing fs errors', async () => {
+			await using pkg = await createPackage({
+				pkg: {
+					'package.json': createPackageJson({ exports: './a.mjs' }),
+					'a.mjs': 'export default 1',
+				},
+			});
+
+			const failingFs = new Proxy(fs, {
+				get(target, property) {
+					if (property === 'lstatSync') {
+						return () => {
+							throw Object.assign(new Error('denied'), { code: 'EACCES' });
+						};
+					}
+					return target[property as keyof typeof target];
+				},
+			});
+
+			expect(() => getPackageEntryPointsSync(pkg.packagePath, failingFs)).toThrow('denied');
 		});
 	});
 });

--- a/tests/specs/discovery.ts
+++ b/tests/specs/discovery.ts
@@ -172,6 +172,36 @@ export default testSuite(({ describe }) => {
 						'./a': [[['default'], './dist/a.mjs']],
 					});
 				});
+
+				test('trailing separator on packagePath (legacy)', async () => {
+					await using pkg = await createPackage({
+						pkg: {
+							'package.json': createPackageJson({ main: './index.js' }),
+							'index.js': 'module.exports = 1',
+						},
+					});
+
+					const withSeparator = await getEntries(pkg.packagePath + path.sep);
+					expect(withSeparator).toStrictEqual({
+						'.': [[['default'], './index.js']],
+						'./index.js': [[['default'], './index.js']],
+						'./package.json': [[['default'], './package.json']],
+					});
+				});
+
+				test('wildcard pointing at a missing directory yields nothing', async () => {
+					await using pkg = await createPackage({
+						pkg: {
+							'package.json': createPackageJson({
+								exports: { './*': './missing/*.mjs' },
+							}),
+							'index.js': '',
+						},
+					});
+
+					const result = await getEntries(pkg.packagePath);
+					expect(result).toStrictEqual({});
+				});
 			});
 		});
 	}
@@ -181,65 +211,54 @@ export default testSuite(({ describe }) => {
 	 * changes which fs calls happen, so lock that a custom fs is used and works.
 	 */
 	describe('custom fs', ({ test }) => {
+		// A Proxy delegates every method, so the test stays valid as the set of
+		// fs calls evolves (e.g. discovery added `lstat`). It records which
+		// methods were accessed to confirm the injected fs is actually used.
 		test('async uses the provided fs', async () => {
 			await using pkg = await createPackage({
 				pkg: {
-					'package.json': createPackageJson({ exports: './a.mjs' }),
-					'a.mjs': 'export default 1',
+					'package.json': createPackageJson({ exports: { './*': './dist/*.mjs' } }),
+					'dist/a.mjs': 'export default 1',
 				},
 			});
 
-			const calls = {
-				readFile: 0,
-				readdir: 0,
-			};
-			const customFs = {
-				readFile: (...args: Parameters<typeof fs.promises.readFile>) => {
-					calls.readFile += 1;
-					return fs.promises.readFile(...args);
+			const used = new Set<string>();
+			const trackingFs = new Proxy(fs.promises, {
+				get(target, property) {
+					used.add(property.toString());
+					return target[property as keyof typeof target];
 				},
-				readdir: (...args: Parameters<typeof fs.promises.readdir>) => {
-					calls.readdir += 1;
-					return fs.promises.readdir(...args);
-				},
-			} as unknown as typeof fs.promises;
+			});
 
-			const result = await getPackageEntryPoints(pkg.packagePath, customFs);
-			expect(calls.readFile).toBeGreaterThan(0);
-			expect(calls.readdir).toBeGreaterThan(0);
+			const result = await getPackageEntryPoints(pkg.packagePath, trackingFs);
+			expect(used.has('readFile')).toBe(true);
+			expect(used.has('readdir')).toBe(true);
 			expect(result).toStrictEqual({
-				'.': [[['default'], './a.mjs']],
+				'./a': [[['default'], './dist/a.mjs']],
 			});
 		});
 
 		test('sync uses the provided fs', async () => {
 			await using pkg = await createPackage({
 				pkg: {
-					'package.json': createPackageJson({ exports: './a.mjs' }),
-					'a.mjs': 'export default 1',
+					'package.json': createPackageJson({ exports: { './*': './dist/*.mjs' } }),
+					'dist/a.mjs': 'export default 1',
 				},
 			});
 
-			const calls = {
-				readFileSync: 0,
-				readdirSync: 0,
-			};
-			const customFs = {
-				readFileSync: (...args: Parameters<typeof fs.readFileSync>) => {
-					calls.readFileSync += 1;
-					return fs.readFileSync(...args);
+			const used = new Set<string>();
+			const trackingFs = new Proxy(fs, {
+				get(target, property) {
+					used.add(property.toString());
+					return target[property as keyof typeof target];
 				},
-				readdirSync: (...args: Parameters<typeof fs.readdirSync>) => {
-					calls.readdirSync += 1;
-					return fs.readdirSync(...args);
-				},
-			} as unknown as typeof fs;
+			});
 
-			const result = getPackageEntryPointsSync(pkg.packagePath, customFs);
-			expect(calls.readFileSync).toBeGreaterThan(0);
-			expect(calls.readdirSync).toBeGreaterThan(0);
+			const result = getPackageEntryPointsSync(pkg.packagePath, trackingFs);
+			expect(used.has('readFileSync')).toBe(true);
+			expect(used.has('readdirSync')).toBe(true);
 			expect(result).toStrictEqual({
-				'.': [[['default'], './a.mjs']],
+				'./a': [[['default'], './dist/a.mjs']],
 			});
 		});
 	});

--- a/tests/specs/discovery.ts
+++ b/tests/specs/discovery.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { testSuite, expect } from 'manten';
+import { createFixture } from 'fs-fixture';
 import { createPackage, createPackageJson, testScenarios } from '../utils.js';
 import { getPackageEntryPoints, getPackageEntryPointsSync } from '#pkg-entry-points';
 
@@ -216,6 +217,21 @@ export default testSuite(({ describe }) => {
 
 					const result = await getEntries(pkg.packagePath);
 					expect(result).toStrictEqual({});
+				});
+
+				test('follows a symlinked package root for root wildcards', async () => {
+					await using fixture = await createFixture({
+						'real-pkg': {
+							'package.json': createPackageJson({ exports: { './*': './*.mjs' } }),
+							'a.mjs': 'export default 1',
+						},
+						'node_modules/pkg': ({ symlink, getPath }) => symlink(getPath('real-pkg'), 'dir'),
+					});
+
+					const result = await getEntries(fixture.getPath('node_modules/pkg'));
+					expect(result).toStrictEqual({
+						'./a': [[['default'], './a.mjs']],
+					});
 				});
 
 				test('rejects path-escaping and invalid export targets', async () => {

--- a/tests/specs/discovery.ts
+++ b/tests/specs/discovery.ts
@@ -34,14 +34,12 @@ export default testSuite(({ describe }) => {
 				});
 
 				/**
-				 * KNOWN DIVERGENCE: Node's recursive `readdirSync` follows symlinked
-				 * directories, but async `readdir` does not (Node 24). So sync lists
-				 * files under a symlinked dir and async doesn't. Pinned so the
-				 * difference is visible; Phase 2's manual walk is the natural place to
-				 * unify them to the async behavior (don't follow). See the divergences
-				 * note in .project-notes.
+				 * The manual walk skips symlinked directories (`isDirectory()` is
+				 * false for a symlink) in both sync and async. This unifies a prior
+				 * divergence where recursive `readdirSync` followed symlinked dirs but
+				 * async `readdir` did not.
 				 */
-				test('symlinked directory (sync follows, async does not)', async () => {
+				test('does not follow symlinked directories', async () => {
 					await using pkg = await createPackage({
 						pkg: {
 							'package.json': createPackageJson({ main: './index.js' }),
@@ -52,20 +50,12 @@ export default testSuite(({ describe }) => {
 					});
 
 					const result = await getEntries(pkg.packagePath);
-					const base = {
+					expect(result).toStrictEqual({
 						'.': [[['default'], './index.js']],
 						'./index.js': [[['default'], './index.js']],
 						'./real/deep.js': [[['default'], './real/deep.js']],
 						'./package.json': [[['default'], './package.json']],
-					};
-					expect(result).toStrictEqual(
-						scenario === 'sync'
-							? {
-								...base,
-								'./linked/deep.js': [[['default'], './linked/deep.js']],
-							}
-							: base,
-					);
+					});
 				});
 
 				/**


### PR DESCRIPTION
## Problem

`getPackageEntryPoints` always scanned the **entire** package tree (`readdir({ recursive: true })`), then discarded most of it. For an `exports` package, the file list is only needed to expand `*` patterns and existence-check explicit targets — so walking `src/`, `test/`, type maps, and (root) `node_modules` is wasted work. On a real package the walk is ~90% of the call.

## Changes

Two commits, each behavior-preserving (see validation):

1. **`perf: replace recursive readdir with a pruned manual walk`** — `getAllFiles` now walks directory-by-directory so it can prune the root `node_modules` *without descending into it*, skip symlinks, and build paths by concatenation. (Files under a *nested* `node_modules` are still listed, as before.)
2. **`perf: discover only files referenced by exports`** — the `exports` path no longer does a full scan. It walks only the directory each wildcard target points into (scoped to the prefix before the first `*`) and `lstat`s each explicit target, then feeds that scoped set into the unchanged `analyzeExportsWithFiles`. Legacy (no `exports`) still does the full walk.

## Validation

- **Equivalence vs the old full-scan on 1759 real packages from the local store (991 with `exports`): 0 output diffs.**
- 128 tests pass (the #41 net plus discovery edge cases), type-check + lint clean, on both the source and built-dist paths.

### Edge cases hardened (via review)

The scoped path reasons about real paths, so it needs guards the full scan got for free:
- **Invalid / path-escaping targets** (`./dist/../x`, `./../../secret`, `./node_modules/x`, and Windows `..\x`) are rejected before any `lstat`, matching Node's `PACKAGE_TARGET_RESOLVE` and the old scan (which never matched them).
- **fs errors surface**: only `ENOENT`/`ENOTDIR` are treated as "missing"; `EACCES` etc. now throw instead of silently yielding `{}`.
- **Symlinks**: a symlinked *package root* (pnpm/yarn `node_modules/<pkg>`) is followed for root wildcards, while symlinked *subdirectories* are not — consistent with the full walk.
- Coverage: `get-all-files.ts` 100%; overall 98.8 / 97.4 (stmt/branch).

## Performance

Real filesystem, warm cache, 9,201-file package (1,000 referenced under `./dist`, the rest unreferenced `src`/`coverage`/`node_modules`):

| | full scan | scoped | speedup |
|---|--:|--:|--:|
| `getPackageEntryPoints` end-to-end | 4.99 ms | 0.97 ms | **5.1x** |

The win scales with how much of the tree is unreferenced and is larger cold (it never touches the unrelated inodes). Packages that publish only `dist` see less; packages with large `src`/bundled deps see more.

## Behavior change vs the last release (1.1.1)

Output is byte-identical to released **1.1.1** across **1759 installed packages (991 with `exports`) — 0 diffs**. The only difference is **symlinks inside a package directory**:

- 1.1.1 walked with `statSync`, which *follows* symlinks — it listed symlinked files and files under symlinked directories as entry points.
- This PR's manual walk uses `isFile()`/`isDirectory()` on the dir entry, so it does **not** follow symlinks, consistently in both sync and async.

Most of this already changed on `develop` (the earlier switch to recursive `readdir` stopped listing symlinked files and left sync≠async for symlinked dirs); this PR makes the two APIs consistent. It affects **0 of the 1759 real packages tested** — npm doesn't ship symlinks inside packages, so it's a local/monorepo-only edge. The pinned #41 test was updated to assert the unified behavior.

Worth a one-line release note ("symlinks inside a package are no longer followed"); not a practical break.

## Not included (parked findings)

- path-matcher last-star validation (`./*-*.js` matching `a-b.js`) — separate fix.
- exporting the `PackageEntryPoints` type — separate.


