### PR TITLE
fix: star-capture matching and missing public type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"c8": "^11.0.0",
 		"clean-pkg-json": "^1.3.0",
 		"execa": "^9.6.1",
+		"expect-type": "^1.3.0",
 		"fs-fixture": "^2.9.0",
 		"lintroll": "^1.23.4",
 		"manten": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       execa:
         specifier: ^9.6.1
         version: 9.6.1
+      expect-type:
+        specifier: ^1.3.0
+        version: 1.3.0
       fs-fixture:
         specifier: ^2.9.0
         version: 2.9.0
@@ -1514,6 +1517,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -4262,6 +4269,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import type {
 	ConditionsMap, PackageEntryPoints, StarMatch, ConditionToPath,
 } from './types.js';
 
+export type { PackageEntryPoints, ConditionToPath } from './types.js';
+
 type GetConditions = {
 	(
 		packageFiles: string[],

--- a/src/utils/path-matcher.ts
+++ b/src/utils/path-matcher.ts
@@ -43,7 +43,7 @@ export const pathMatches = (
 	}
 
 	let lastIndex = 0;
-	let starValue = '';
+	let starValue: string | undefined;
 	for (const segment of middleSegments) {
 		const segmentIndex = filePathMiddle.indexOf(segment, lastIndex);
 		if (segmentIndex === -1) {
@@ -51,13 +51,19 @@ export const pathMatches = (
 		}
 
 		const extracted = filePathMiddle.slice(lastIndex, segmentIndex);
-		if (!starValue) {
+		if (starValue === undefined) {
 			starValue = extracted;
 		} else if (starValue !== extracted) {
 			return;
 		}
 
 		lastIndex = segmentIndex + segment.length;
+	}
+
+	// Every `*` binds to the same capture, including the final one before the
+	// suffix — otherwise `*-*.js` would wrongly match `a-b.js`.
+	if (starValue !== filePathMiddle.slice(lastIndex)) {
+		return;
 	}
 
 	return starValue;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -7,5 +7,6 @@ describe('pkg-entry-points', ({ runTestSuite }) => {
 	runTestSuite(import('./specs/merge-conditions.js'));
 	runTestSuite(import('./specs/no-exports.js'));
 	runTestSuite(import('./specs/discovery.js'));
+	runTestSuite(import('./specs/public-types.js'));
 	runTestSuite(import('./specs/nodejs-behavior.js'));
 });

--- a/tests/specs/discovery.ts
+++ b/tests/specs/discovery.ts
@@ -142,6 +142,29 @@ export default testSuite(({ describe }) => {
 					});
 				});
 
+				/**
+				 * Every `*` in a pattern binds to the same capture, including the
+				 * final one before the suffix. The prior matcher never checked the
+				 * trailing segment, so `*-*.mjs` wrongly matched `b-c.mjs` (capturing
+				 * `b`). Node rejects it, so only the consistent `a-a.mjs` survives.
+				 */
+				test('trailing star must match the captured value', async () => {
+					await using pkg = await createPackage({
+						pkg: {
+							'package.json': createPackageJson({
+								exports: { './*': './dir/*-*.mjs' },
+							}),
+							'dir/a-a.mjs': 'export default 1',
+							'dir/b-c.mjs': 'export default 2',
+						},
+					});
+
+					const result = await getEntries(pkg.packagePath);
+					expect(result).toStrictEqual({
+						'./a': [[['default'], './dir/a-a.mjs']],
+					});
+				});
+
 				test('bare main without "./" prefix', async () => {
 					await using pkg = await createPackage({
 						pkg: {

--- a/tests/specs/public-types.ts
+++ b/tests/specs/public-types.ts
@@ -1,0 +1,21 @@
+import { testSuite, expect } from 'manten';
+import type { ConditionToPath, PackageEntryPoints } from '#pkg-entry-points';
+
+/**
+ * The README documents `PackageEntryPoints` and `ConditionToPath` as the
+ * public return types, so they must be importable from the package entry.
+ * Annotating these values is the real assertion: `type-check` fails if either
+ * type stops being exported. The runtime check just exercises the shape.
+ */
+export default testSuite(({ test }) => {
+	test('re-exports its documented public types', () => {
+		const conditionToPath: ConditionToPath = [['default'], './index.js'];
+		const entryPoints: PackageEntryPoints = {
+			'.': [conditionToPath],
+		};
+
+		expect(entryPoints).toStrictEqual({
+			'.': [[['default'], './index.js']],
+		});
+	});
+});

--- a/tests/specs/public-types.ts
+++ b/tests/specs/public-types.ts
@@ -1,21 +1,21 @@
-import { testSuite, expect } from 'manten';
+import { testSuite } from 'manten';
+import { expectTypeOf } from 'expect-type';
 import type { ConditionToPath, PackageEntryPoints } from '#pkg-entry-points';
 
 /**
  * The README documents `PackageEntryPoints` and `ConditionToPath` as the
- * public return types, so they must be importable from the package entry.
- * Annotating these values is the real assertion: `type-check` fails if either
- * type stops being exported. The runtime check just exercises the shape.
+ * public return types, so they must stay importable from the package entry
+ * with their documented shape. These assertions are checked by `type-check`:
+ * it fails if either export is dropped or its shape drifts.
  */
 export default testSuite(({ test }) => {
 	test('re-exports its documented public types', () => {
-		const conditionToPath: ConditionToPath = [['default'], './index.js'];
-		const entryPoints: PackageEntryPoints = {
-			'.': [conditionToPath],
-		};
+		expectTypeOf<ConditionToPath>().toEqualTypeOf<
+			[conditions: string[], internalPath: string]
+		>();
 
-		expect(entryPoints).toStrictEqual({
-			'.': [[['default'], './index.js']],
-		});
+		expectTypeOf<PackageEntryPoints>().toEqualTypeOf<{
+			[subpath: string]: ConditionToPath[];
+		}>();
 	});
 });


### PR DESCRIPTION
## Problem

Two independent correctness gaps:

1. **Star matching ignored the final capture.** `pathMatches` validated every `*` capture *except* the last one before the suffix, so an `exports` target like `./dir/*-*.mjs` wrongly matched `b-c.mjs` (capturing `b`) and emitted a `./b` entry point that Node refuses to resolve.
2. **Documented public types weren't exported.** The README documents `PackageEntryPoints` and `ConditionToPath` as the return-type contract, but neither was exported from the entry, so `import type { PackageEntryPoints } from 'pkg-entry-points'` failed.

## Changes

- `pathMatches` now requires the trailing star to equal the shared capture (and tracks "unset" with `undefined` instead of `''`, which also fixes empty-capture handling). `./*-*.js` no longer matches `a-b.js` — matching Node.
- `export type { PackageEntryPoints, ConditionToPath }` from `src/index.ts`. Verified present in the built `.d.mts`/`.d.cts`.
- Tests: `trailing star must match the captured value` (discovery, async + sync) and a `public-types` spec that locks the exports under `tsc`.

## Validation

- `type-check` clean; `lint` 0 errors; **131 tests** pass on both the `src` (development condition) and built `dist` paths.
- Equivalence vs released `1.1.1` and `develop` across 2654 installed packages (1311 with `exports`): **the branch adds 0 runtime output diffs vs `develop`**. The matcher fix triggers on no real package (the inconsistent multi-star pattern is that rare); the type export is type-only.
